### PR TITLE
Generate a random single digit to obfuscate static values

### DIFF
--- a/Bot.c
+++ b/Bot.c
@@ -124,9 +124,9 @@ DWORD IdleProc(LPVOID lpParams)
 			uint16_t nCount;
 			char *seed = "1ad";
 
-			// Send idle key from seed string to client
+			// Send idle key from seed string to client, ranum to obfuscate IDLEINTERVAL
 			SendKeys(hGuildWars, seed[(rand() % sizeof(seed))], RandOffset(1, MS_ENABLED));
-			for ( nCount = 0; nCount < IDLEINTERVAL; nCount++ )
+			for (nCount = 0; nCount < (IDLEINTERVAL + ranum()); nCount++)
 			{
 				if ( g_GlobalSettings.AFK_EXECUTE )
 					Sleep((rand() % 5) + 1000);

--- a/Globals.c
+++ b/Globals.c
@@ -114,3 +114,9 @@ DWORD RandOffset(DWORD dwOrigValue, int nMilliseconds)
 	}
 	return dwNewValue;
 }
+
+// Generate a random single digit using different method to obfuscate static values like IDLEINTERVAL
+
+int ranum() {
+	return (((double)rand() / RAND_MAX) * 10);
+}


### PR DESCRIPTION
Generate a random single digit using a slightly different method from the current RNG, to fuzz static intervals like IDLEINTERVAL. If the AFK interval is set to 30 seconds, this will require nCount to be greater than a random number between 30 and 39 for true, further obfuscating the interval between seed actions being sent